### PR TITLE
Adding timeouts as deploys failing at 40min default

### DIFF
--- a/groups/heritage-shared-infrastructure/rds.tf
+++ b/groups/heritage-shared-infrastructure/rds.tf
@@ -92,6 +92,12 @@ module "rds" {
     },
   ]
 
+  timeouts = {
+    "create" : "80m",
+    "delete" : "80m",
+    "update" : "80m"
+  }
+
   tags = merge(
     local.default_tags,
     map(


### PR DESCRIPTION
Timeouts reached for deployment, increasing timeouts in code for easier deployments.