### PR TITLE
Removing old SESS RDS instance and components as now unused with latest SESSIONS migration complete.

### DIFF
--- a/groups/heritage-shared-infrastructure/data.tf
+++ b/groups/heritage-shared-infrastructure/data.tf
@@ -82,10 +82,6 @@ data "vault_generic_secret" "chdata_rds" {
   path = "applications/${var.aws_profile}/chdata/rds"
 }
 
-data "vault_generic_secret" "sess_rds" {
-  path = "applications/${var.aws_profile}/sess/rds"
-}
-
 data "vault_generic_secret" "internal_cidrs" {
   path = "aws-accounts/network/internal_cidr_ranges"
 }

--- a/groups/heritage-shared-infrastructure/locals.tf
+++ b/groups/heritage-shared-infrastructure/locals.tf
@@ -7,7 +7,6 @@ locals {
   rds_data = {
     bcd    = data.vault_generic_secret.bcd_rds.data
     chdata = data.vault_generic_secret.chdata_rds.data
-    sess   = data.vault_generic_secret.sess_rds.data
   }
 
   internal_fqdn = format("%s.%s.aws.internal", split("-", var.aws_account)[1], split("-", var.aws_account)[0])
@@ -78,22 +77,6 @@ locals {
         protocol                 = "tcp"
         description              = "Frontend Tuxedo XML"
         source_security_group_id = data.aws_security_group.xml_fe_tux.id
-      }
-    ]
-    "sess" = [
-      {
-        from_port                = 1521
-        to_port                  = 1521
-        protocol                 = "tcp"
-        description              = "Frontend EWF"
-        source_security_group_id = data.aws_security_group.ewf_fe_asg.id
-      },
-      {
-        from_port                = 1521
-        to_port                  = 1521
-        protocol                 = "tcp"
-        description              = "Backend EWF"
-        source_security_group_id = data.aws_security_group.ewf_bep_asg.id
       }
     ]
   }

--- a/groups/heritage-shared-infrastructure/profiles/heritage-development-eu-west-2/vars
+++ b/groups/heritage-shared-infrastructure/profiles/heritage-development-eu-west-2/vars
@@ -10,107 +10,73 @@ environment = "development"
 
 
 rds_databases = {
-    bcd = {
-      instance_class             = "db.t3.medium"
-      allocated_storage          = 20
-      backup_retention_period    = 2
-      multi_az                   = false
-      engine                     = "oracle-se2"
-      major_engine_version       = "12.1"
-      engine_version             = "12.1.0.2.v23"
-      auto_minor_version_upgrade = true
-      license_model              = "license-included"
-      rds_maintenance_window     = "Thu:00:00-Thu:03:00"
-      rds_backup_window          = "03:00-06:00"
-      rds_log_exports            = [
-            "alert",
-            "audit",
-            "listener",
-            "trace"
-      ],
-      rds_onpremise_access = [
-        "192.168.90.0/24",
-        "192.168.70.0/24"
-      ]
-      per_instance_options = [
-        {
-          option_name = "Timezone"
-          option_settings = [
-            {
-              name  = "TIME_ZONE"
-              value = "Europe/London"
-            },
-          ]
-        },
-      ]
-    },
-    chdata = {
-      instance_class             = "db.t3.medium"
-      allocated_storage          = 20
-      backup_retention_period    = 2
-      multi_az                   = false
-      engine                     = "oracle-se2"
-      major_engine_version       = "12.1"
-      engine_version             = "12.1.0.2.v23"
-      auto_minor_version_upgrade = true
-      license_model              = "license-included"
-      rds_maintenance_window     = "Thu:00:00-Thu:03:00"
-      rds_backup_window          = "03:00-06:00"
-      rds_log_exports            = [
-            "alert",
-            "audit",
-            "listener",
-            "trace"
-      ],
-      rds_onpremise_access = [
-        "192.168.90.0/24",
-        "192.168.70.0/24"
-      ]
-      per_instance_options = [
-        {
-          option_name = "Timezone"
-          option_settings = [
-            {
-              name  = "TIME_ZONE"
-              value = "Europe/London"
-            },
-          ]
-        },
-      ]
-    },
-    sess = {
-      instance_class             = "db.t3.medium"
-      allocated_storage          = 20
-      backup_retention_period    = 2
-      multi_az                   = false
-      engine                     = "oracle-se2"
-      major_engine_version       = "12.1"
-      engine_version             = "12.1.0.2.v23"
-      auto_minor_version_upgrade = true
-      license_model              = "license-included"
-      rds_maintenance_window     = "Thu:00:00-Thu:03:00"
-      rds_backup_window          = "03:00-06:00"
-      rds_log_exports            = [
-            "alert",
-            "audit",
-            "listener",
-            "trace"
-      ],
-      rds_onpremise_access = [
-        "192.168.90.0/24",
-        "192.168.70.0/24"
-      ]
-      per_instance_options = [
-        {
-          option_name = "Timezone"
-          option_settings = [
-            {
-              name  = "TIME_ZONE"
-              value = "Europe/London"
-            },
-          ]
-        },
-      ]
+  bcd = {
+    instance_class             = "db.t3.medium"
+    allocated_storage          = 20
+    backup_retention_period    = 2
+    multi_az                   = false
+    engine                     = "oracle-se2"
+    major_engine_version       = "12.1"
+    engine_version             = "12.1.0.2.v23"
+    auto_minor_version_upgrade = true
+    license_model              = "license-included"
+    rds_maintenance_window     = "Thu:00:00-Thu:03:00"
+    rds_backup_window          = "03:00-06:00"
+    rds_log_exports            = [
+          "alert",
+          "audit",
+          "listener",
+          "trace"
+    ],
+    rds_onpremise_access = [
+      "192.168.90.0/24",
+      "192.168.70.0/24"
+    ]
+    per_instance_options = [
+      {
+        option_name = "Timezone"
+        option_settings = [
+          {
+            name  = "TIME_ZONE"
+            value = "Europe/London"
+          },
+        ]
+      },
+    ]
+  },
+  chdata = {
+    instance_class             = "db.t3.medium"
+    allocated_storage          = 20
+    backup_retention_period    = 2
+    multi_az                   = false
+    engine                     = "oracle-se2"
+    major_engine_version       = "12.1"
+    engine_version             = "12.1.0.2.v23"
+    auto_minor_version_upgrade = true
+    license_model              = "license-included"
+    rds_maintenance_window     = "Thu:00:00-Thu:03:00"
+    rds_backup_window          = "03:00-06:00"
+    rds_log_exports            = [
+          "alert",
+          "audit",
+          "listener",
+          "trace"
+    ],
+    rds_onpremise_access = [
+      "192.168.90.0/24",
+      "192.168.70.0/24"
+    ]
+    per_instance_options = [
+      {
+        option_name = "Timezone"
+        option_settings = [
+          {
+            name  = "TIME_ZONE"
+            value = "Europe/London"
+          },
+        ]
+      },
+    ]
   }
 }
 

--- a/groups/heritage-shared-infrastructure/profiles/heritage-live-eu-west-2/vars
+++ b/groups/heritage-shared-infrastructure/profiles/heritage-live-eu-west-2/vars
@@ -9,118 +9,75 @@ region      = "euw2"
 environment = "live"
 
 rds_databases = {
-    bcd = {
-      instance_class             = "db.m5.xlarge"
-      allocated_storage          = 150
-      backup_retention_period    = 2
-      multi_az                   = true
-      engine                     = "oracle-se2"
-      major_engine_version       = "12.1"
-      engine_version             = "12.1.0.2.v23"
-      auto_minor_version_upgrade = true
-      license_model              = "license-included"
-      rds_maintenance_window     = "Wed:00:00-Wed:03:00"
-      rds_backup_window          = "03:00-06:00"
-      rds_log_exports            = [
-            "alert",
-            "audit",
-            "listener",
-            "trace"
-      ],
-      rds_onpremise_access = [
-        "192.168.90.0/24",
-        "192.168.70.0/24",
-        "192.168.60.0/24"
-      ]
-      per_instance_options = [
-        {
-          option_name = "Timezone"
-          option_settings = [
-            {
-              name  = "TIME_ZONE"
-              value = "Europe/London"
-            },
-          ]
-        },
-      ]
-    },
-    chdata = {
-      instance_class             = "db.m5.2xlarge"
-      allocated_storage          = 40
-      backup_retention_period    = 2
-      multi_az                   = true
-      engine                     = "oracle-se2"
-      major_engine_version       = "12.1"
-      engine_version             = "12.1.0.2.v23"
-      auto_minor_version_upgrade = true
-      license_model              = "license-included"
-      rds_maintenance_window     = "Wed:00:00-Wed:03:00"
-      rds_backup_window          = "03:00-06:00"
-      rds_log_exports            = [
-            "alert",
-            "audit",
-            "listener",
-            "trace"
-      ],
-      rds_onpremise_access = [
-        "192.168.90.0/24",
-        "192.168.70.0/24"
-      ]
-      per_instance_options = [
-        {
-          option_name = "Timezone"
-          option_settings = [
-            {
-              name  = "TIME_ZONE"
-              value = "Europe/London"
-            },
-          ]
-        },
-      ]
-    },
-    sess = {
-      instance_class             = "db.m5.4xlarge"
-      allocated_storage          = 40
-      backup_retention_period    = 2
-      multi_az                   = true
-      engine                     = "oracle-se2"
-      major_engine_version       = "12.1"
-      engine_version             = "12.1.0.2.v23"
-      auto_minor_version_upgrade = true
-      license_model              = "license-included"
-      rds_maintenance_window     = "Wed:00:00-Wed:03:00"
-      rds_backup_window          = "03:00-06:00"
-      rds_log_exports            = [
-            "alert",
-            "audit",
-            "listener",
-            "trace"
-      ],
-      rds_onpremise_access = [
-        "10.55.2.0/24",
-        "10.55.66.0/24",
-        "10.55.130.0/24",
-        "172.24.4.17/32",
-        "192.168.70.0/24",
-        "192.168.90.0/24",
-        "192.168.60.130/32", 
-        "192.168.60.131/32", 
-        "192.168.60.132/32", 
-        "192.168.60.133/32", 
-        "192.168.60.134/32"
-      ]
-      per_instance_options = [
-        {
-          option_name = "Timezone"
-          option_settings = [
-            {
-              name  = "TIME_ZONE"
-              value = "Europe/London"
-            },
-          ]
-        },
-      ]
-    }
+  bcd = {
+    instance_class             = "db.m5.xlarge"
+    allocated_storage          = 150
+    backup_retention_period    = 2
+    multi_az                   = true
+    engine                     = "oracle-se2"
+    major_engine_version       = "12.1"
+    engine_version             = "12.1.0.2.v23"
+    auto_minor_version_upgrade = true
+    license_model              = "license-included"
+    rds_maintenance_window     = "Wed:00:00-Wed:03:00"
+    rds_backup_window          = "03:00-06:00"
+    rds_log_exports            = [
+          "alert",
+          "audit",
+          "listener",
+          "trace"
+    ],
+    rds_onpremise_access = [
+      "192.168.90.0/24",
+      "192.168.70.0/24",
+      "192.168.60.0/24"
+    ]
+    per_instance_options = [
+      {
+        option_name = "Timezone"
+        option_settings = [
+          {
+            name  = "TIME_ZONE"
+            value = "Europe/London"
+          },
+        ]
+      },
+    ]
+  },
+  chdata = {
+    instance_class             = "db.m5.2xlarge"
+    allocated_storage          = 40
+    backup_retention_period    = 2
+    multi_az                   = true
+    engine                     = "oracle-se2"
+    major_engine_version       = "12.1"
+    engine_version             = "12.1.0.2.v23"
+    auto_minor_version_upgrade = true
+    license_model              = "license-included"
+    rds_maintenance_window     = "Wed:00:00-Wed:03:00"
+    rds_backup_window          = "03:00-06:00"
+    rds_log_exports            = [
+          "alert",
+          "audit",
+          "listener",
+          "trace"
+    ],
+    rds_onpremise_access = [
+      "192.168.90.0/24",
+      "192.168.70.0/24"
+    ]
+    per_instance_options = [
+      {
+        option_name = "Timezone"
+        option_settings = [
+          {
+            name  = "TIME_ZONE"
+            value = "Europe/London"
+          },
+        ]
+      },
+    ]
+  }
 }
 
 # RDS Param and Option settings

--- a/groups/heritage-shared-infrastructure/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/heritage-shared-infrastructure/profiles/heritage-staging-eu-west-2/vars
@@ -9,110 +9,74 @@ region      = "euw2"
 environment = "staging"
 
 rds_databases = {
-    bcd = {
-      instance_class             = "db.m5.large"
-      allocated_storage          = 50
-      backup_retention_period    = 2
-      multi_az                   = true
-      engine                     = "oracle-se2"
-      major_engine_version       = "12.1"
-      engine_version             = "12.1.0.2.v23"
-      auto_minor_version_upgrade = true
-      license_model              = "license-included"
-      rds_maintenance_window     = "Sun:00:00-Sun:03:00"
-      rds_backup_window          = "03:00-06:00"
-      rds_log_exports            = [
-            "alert",
-            "audit",
-            "listener",
-            "trace"
-      ],
-      rds_onpremise_access = [
-        "192.168.90.0/24",
-        "192.168.70.0/24"
-      ]
-      per_instance_options = [
-        {
-          option_name = "Timezone"
-          option_settings = [
-            {
-              name  = "TIME_ZONE"
-              value = "Europe/London"
-            },
-          ]
-        },
-      ]
-    },
-    chdata = {
-      instance_class             = "db.m5.large"
-      allocated_storage          = 30
-      backup_retention_period    = 2
-      multi_az                   = true
-      engine                     = "oracle-se2"
-      major_engine_version       = "12.1"
-      engine_version             = "12.1.0.2.v23"
-      auto_minor_version_upgrade = true
-      license_model              = "license-included"
-      rds_maintenance_window     = "Sun:00:00-Sun:03:00"
-      rds_backup_window          = "03:00-06:00"
-      rds_log_exports            = [
-            "alert",
-            "audit",
-            "listener",
-            "trace"
-      ],
-      rds_onpremise_access = [
-        "192.168.90.0/24",
-        "192.168.70.0/24"
-      ]
-      per_instance_options = [
-        {
-          option_name = "Timezone"
-          option_settings = [
-            {
-              name  = "TIME_ZONE"
-              value = "Europe/London"
-            },
-          ]
-        },
-      ]
-    },
-    sess = {
-      instance_class             = "db.m5.large"
-      allocated_storage          = 30
-      backup_retention_period    = 2
-      multi_az                   = true
-      engine                     = "oracle-se2"
-      major_engine_version       = "12.1"
-      engine_version             = "12.1.0.2.v23"
-      auto_minor_version_upgrade = true
-      license_model              = "license-included"
-      rds_maintenance_window     = "Sun:00:00-Sun:03:00"
-      rds_backup_window          = "03:00-06:00"
-      rds_log_exports            = [
-            "alert",
-            "audit",
-            "listener",
-            "trace"
-      ],
-      rds_onpremise_access = [
-        "10.65.2.0/24",
-        "10.65.66.0/24",
-        "10.65.130.0/24",
-        "192.168.70.0/24",
-        "192.168.90.0/24"
-      ]
-      per_instance_options = [
-        {
-          option_name = "Timezone"
-          option_settings = [
-            {
-              name  = "TIME_ZONE"
-              value = "Europe/London"
-            },
-          ]
-        },
-      ]    }
+  bcd = {
+    instance_class             = "db.m5.large"
+    allocated_storage          = 50
+    backup_retention_period    = 2
+    multi_az                   = true
+    engine                     = "oracle-se2"
+    major_engine_version       = "12.1"
+    engine_version             = "12.1.0.2.v23"
+    auto_minor_version_upgrade = true
+    license_model              = "license-included"
+    rds_maintenance_window     = "Sun:00:00-Sun:03:00"
+    rds_backup_window          = "03:00-06:00"
+    rds_log_exports            = [
+          "alert",
+          "audit",
+          "listener",
+          "trace"
+    ],
+    rds_onpremise_access = [
+      "192.168.90.0/24",
+      "192.168.70.0/24"
+    ]
+    per_instance_options = [
+      {
+        option_name = "Timezone"
+        option_settings = [
+          {
+            name  = "TIME_ZONE"
+            value = "Europe/London"
+          },
+        ]
+      },
+    ]
+  },
+  chdata = {
+    instance_class             = "db.m5.large"
+    allocated_storage          = 30
+    backup_retention_period    = 2
+    multi_az                   = true
+    engine                     = "oracle-se2"
+    major_engine_version       = "12.1"
+    engine_version             = "12.1.0.2.v23"
+    auto_minor_version_upgrade = true
+    license_model              = "license-included"
+    rds_maintenance_window     = "Sun:00:00-Sun:03:00"
+    rds_backup_window          = "03:00-06:00"
+    rds_log_exports            = [
+          "alert",
+          "audit",
+          "listener",
+          "trace"
+    ],
+    rds_onpremise_access = [
+      "192.168.90.0/24",
+      "192.168.70.0/24"
+    ]
+    per_instance_options = [
+      {
+        option_name = "Timezone"
+        option_settings = [
+          {
+            name  = "TIME_ZONE"
+            value = "Europe/London"
+          },
+        ]
+      },
+    ]
+  }
 }
 
 # RDS Param and Option settings

--- a/groups/heritage-shared-infrastructure/route53.tf
+++ b/groups/heritage-shared-infrastructure/route53.tf
@@ -1,5 +1,5 @@
 resource "aws_route53_record" "rds" {
-  for_each = { for key, database in var.rds_databases : key => database if key != "sess" }
+  for_each = { for key, database in var.rds_databases : key => database }
 
   zone_id = data.aws_route53_zone.private_zone.zone_id
   name    = format("%s%s", each.key, "db")


### PR DESCRIPTION
SESSIONS has been created and is now in used by other services, SESS is now old and unnecessary so should be removed to save costs and remove any confusion.