### PR TITLE
Add dynamically created SGs for application access

### DIFF
--- a/groups/heritage-shared-infrastructure/locals.tf
+++ b/groups/heritage-shared-infrastructure/locals.tf
@@ -191,6 +191,9 @@ locals {
     ]
   }
 
+  rds_databases_requiring_app_access = {
+    for key, value in var.rds_databases : key => value if length(value.rds_app_access) > 0
+  }
 
   default_tags = {
     Terraform = "true"

--- a/groups/heritage-shared-infrastructure/rds.tf
+++ b/groups/heritage-shared-infrastructure/rds.tf
@@ -95,7 +95,7 @@ module "rds" {
   vpc_security_group_ids = flatten([
     module.rds_security_group[each.key].this_security_group_id,
     data.aws_security_group.rds_shared.id,
-    [for key, value in module.rds_app_security_group : value.this_security_group_id],
+    [for key, value in module.rds_app_security_group : value.this_security_group_id if key == each.key],
   ])
 
 


### PR DESCRIPTION
Add local var that is populated based on rds_app_access list in rds_databases map
Added SG resource to create a new SG only for RDS instances that have a non-empty rds_app_access list
Updated rds resource security group attachment

Works around a race condition when amending an existing SG that requires replacement causing pipeline to fail due to duplicate resources.