### PR TITLE
Add cics app security group to allow access to rds

### DIFF
--- a/groups/heritage-shared-infrastructure/data.tf
+++ b/groups/heritage-shared-infrastructure/data.tf
@@ -68,6 +68,13 @@ data "aws_security_group" "adminsites" {
   }
 }
 
+data "aws_security_group" "cics_asg" {
+  filter {
+    name   = "tag:Name"
+    values = ["sgr-cics-asg*"]
+  }
+}
+
 data "aws_route53_zone" "private_zone" {
   name         = local.internal_fqdn
   private_zone = true

--- a/groups/heritage-shared-infrastructure/locals.tf
+++ b/groups/heritage-shared-infrastructure/locals.tf
@@ -148,22 +148,8 @@ locals {
         from_port                = 1521
         to_port                  = 1521
         protocol                 = "tcp"
-        description              = "Frontend EWF"
-        source_security_group_id = data.aws_security_group.ewf_fe_asg.id
-      },
-      {
-        from_port                = 1521
-        to_port                  = 1521
-        protocol                 = "tcp"
-        description              = "Backend EWF"
-        source_security_group_id = data.aws_security_group.ewf_bep_asg.id
-      },
-      {
-        from_port                = 1521
-        to_port                  = 1521
-        protocol                 = "tcp"
-        description              = "Frontend Tuxedo EWF"
-        source_security_group_id = data.aws_security_group.ewf_fe_tux.id
+        description              = "CICs App"
+        source_security_group_id = data.aws_security_group.cics_asg.id
       }
     ],
     "fes" = [


### PR DESCRIPTION
Replaced ewf/xml security groups with cics app group, as only the cics app needs access to the cics rds instances.