### PR TITLE
Permit adminsite access to WCK and CHD RDS instances

### DIFF
--- a/groups/heritage-shared-infrastructure/profiles/heritage-live-eu-west-2/vars
+++ b/groups/heritage-shared-infrastructure/profiles/heritage-live-eu-west-2/vars
@@ -100,7 +100,8 @@ rds_databases = {
     ],
     rds_onpremise_access = [
       "192.168.90.0/24",
-      "192.168.70.0/24"
+      "192.168.70.0/24",
+      "192.168.60.0/24"
     ]
     rds_app_access = [
       "10.55.2.0/24",
@@ -139,7 +140,8 @@ rds_databases = {
     ],
     rds_onpremise_access = [
       "192.168.90.0/24",
-      "192.168.70.0/24"
+      "192.168.70.0/24",
+      "192.168.60.0/24"
     ]
     rds_app_access = []
     per_instance_options = [


### PR DESCRIPTION
Updated rds_onpremise_access lists for WCK and CHD for adminsite