### PR TITLE
Add RDS Start/Stop Schedules

### DIFF
--- a/groups/heritage-shared-infrastructure/profiles/heritage-development-eu-west-2/vars
+++ b/groups/heritage-shared-infrastructure/profiles/heritage-development-eu-west-2/vars
@@ -563,9 +563,9 @@ rds_start_stop_schedule = {
     rds_stop_schedule = ""
   },
   cics = {
-    rds_schedule_enable = false
-    rds_start_schedule = ""
-    rds_stop_schedule = ""
+    rds_schedule_enable = true
+    rds_start_schedule = "cron(0 5 * * ? *)"
+    rds_stop_schedule = "cron(0 21 * * ? *)"
   },
   wck = {
     rds_schedule_enable = true

--- a/groups/heritage-shared-infrastructure/profiles/heritage-development-eu-west-2/vars
+++ b/groups/heritage-shared-infrastructure/profiles/heritage-development-eu-west-2/vars
@@ -545,3 +545,31 @@ parameter_group_settings = {
     },
   ]
 }
+
+rds_start_stop_schedule = {
+  bcd = {
+    rds_schedule_enable = false
+    rds_start_schedule = ""
+    rds_stop_schedule = ""
+  },
+  chd = {
+    rds_schedule_enable = true
+    rds_start_schedule = "cron(0 5 * * ? *)"
+    rds_stop_schedule = "cron(0 21 * * ? *)"
+  },
+  chdata = {
+    rds_schedule_enable = false
+    rds_start_schedule = ""
+    rds_stop_schedule = ""
+  },
+  cics = {
+    rds_schedule_enable = false
+    rds_start_schedule = ""
+    rds_stop_schedule = ""
+  },
+  wck = {
+    rds_schedule_enable = true
+    rds_start_schedule = "cron(0 5 * * ? *)"
+    rds_stop_schedule = "cron(0 21 * * ? *)"
+  }
+}

--- a/groups/heritage-shared-infrastructure/profiles/heritage-development-eu-west-2/vars
+++ b/groups/heritage-shared-infrastructure/profiles/heritage-development-eu-west-2/vars
@@ -548,9 +548,9 @@ parameter_group_settings = {
 
 rds_start_stop_schedule = {
   bcd = {
-    rds_schedule_enable = false
-    rds_start_schedule = ""
-    rds_stop_schedule = ""
+    rds_schedule_enable = true
+    rds_start_schedule = "cron(0 5 * * ? *)"
+    rds_stop_schedule = "cron(0 21 * * ? *)"
   },
   chd = {
     rds_schedule_enable = true
@@ -558,9 +558,9 @@ rds_start_stop_schedule = {
     rds_stop_schedule = "cron(0 21 * * ? *)"
   },
   chdata = {
-    rds_schedule_enable = false
-    rds_start_schedule = ""
-    rds_stop_schedule = ""
+    rds_schedule_enable = true
+    rds_start_schedule = "cron(0 5 * * ? *)"
+    rds_stop_schedule = "cron(0 21 * * ? *)"
   },
   cics = {
     rds_schedule_enable = true

--- a/groups/heritage-shared-infrastructure/profiles/heritage-live-eu-west-2/vars
+++ b/groups/heritage-shared-infrastructure/profiles/heritage-live-eu-west-2/vars
@@ -549,3 +549,31 @@ parameter_group_settings = {
     },
   ]
 }
+
+rds_start_stop_schedule = {
+  bcd = {
+    rds_schedule_enable = false
+    rds_start_schedule = ""
+    rds_stop_schedule = ""
+  },
+  chd = {
+    rds_schedule_enable = false
+    rds_start_schedule = ""
+    rds_stop_schedule = ""
+  },
+  chdata = {
+    rds_schedule_enable = false
+    rds_start_schedule = ""
+    rds_stop_schedule = ""
+  },
+  cics = {
+    rds_schedule_enable = false
+    rds_start_schedule = ""
+    rds_stop_schedule = ""
+  },
+  wck = {
+    rds_schedule_enable = false
+    rds_start_schedule = ""
+    rds_stop_schedule = ""
+  }
+}

--- a/groups/heritage-shared-infrastructure/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/heritage-shared-infrastructure/profiles/heritage-staging-eu-west-2/vars
@@ -578,9 +578,9 @@ rds_start_stop_schedule = {
     rds_stop_schedule = ""
   },
   cics = {
-    rds_schedule_enable = false
-    rds_start_schedule = ""
-    rds_stop_schedule = ""
+    rds_schedule_enable = true
+    rds_start_schedule = "cron(0 5 * * ? *)"
+    rds_stop_schedule = "cron(0 21 * * ? *)"
   },
   wck = {
     rds_schedule_enable = true

--- a/groups/heritage-shared-infrastructure/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/heritage-shared-infrastructure/profiles/heritage-staging-eu-west-2/vars
@@ -560,3 +560,31 @@ parameter_group_settings = {
     },
   ],
 }
+
+rds_start_stop_schedule = {
+  bcd = {
+    rds_schedule_enable = false
+    rds_start_schedule = ""
+    rds_stop_schedule = ""
+  },
+  chd = {
+    rds_schedule_enable = true
+    rds_start_schedule = "cron(0 5 * * ? *)"
+    rds_stop_schedule = "cron(0 21 * * ? *)"
+  },
+  chdata = {
+    rds_schedule_enable = false
+    rds_start_schedule = ""
+    rds_stop_schedule = ""
+  },
+  cics = {
+    rds_schedule_enable = false
+    rds_start_schedule = ""
+    rds_stop_schedule = ""
+  },
+  wck = {
+    rds_schedule_enable = true
+    rds_start_schedule = "cron(0 5 * * ? *)"
+    rds_stop_schedule = "cron(0 21 * * ? *)"
+  }
+}

--- a/groups/heritage-shared-infrastructure/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/heritage-shared-infrastructure/profiles/heritage-staging-eu-west-2/vars
@@ -563,9 +563,9 @@ parameter_group_settings = {
 
 rds_start_stop_schedule = {
   bcd = {
-    rds_schedule_enable = false
-    rds_start_schedule = ""
-    rds_stop_schedule = ""
+    rds_schedule_enable = true
+    rds_start_schedule = "cron(0 5 * * ? *)"
+    rds_stop_schedule = "cron(0 21 * * ? *)"
   },
   chd = {
     rds_schedule_enable = true
@@ -573,9 +573,9 @@ rds_start_stop_schedule = {
     rds_stop_schedule = "cron(0 21 * * ? *)"
   },
   chdata = {
-    rds_schedule_enable = false
-    rds_start_schedule = ""
-    rds_stop_schedule = ""
+    rds_schedule_enable = true
+    rds_start_schedule = "cron(0 5 * * ? *)"
+    rds_stop_schedule = "cron(0 21 * * ? *)"
   },
   cics = {
     rds_schedule_enable = true

--- a/groups/heritage-shared-infrastructure/rds.tf
+++ b/groups/heritage-shared-infrastructure/rds.tf
@@ -141,3 +141,15 @@ module "rds" {
     )
   )
 }
+
+module "rds_start_stop_schedule" {
+  source = "git@github.com:companieshouse/terraform-modules//aws/rds_start_stop_schedule?ref=tags/1.0.131"
+
+  for_each = var.rds_start_stop_schedule
+
+  rds_schedule_enable = lookup(each.value, "rds_schedule_enable", false)
+
+  rds_instance_id     = module.rds[each.key].this_db_instance_id
+  rds_start_schedule  = lookup(each.value, "rds_start_schedule")
+  rds_stop_schedule   = lookup(each.value, "rds_stop_schedule")
+}

--- a/groups/heritage-shared-infrastructure/variables.tf
+++ b/groups/heritage-shared-infrastructure/variables.tf
@@ -50,6 +50,11 @@ variable "parameter_group_settings" {
   description = "A map whose keys represent RDS instances and whose values are a list of parameters that will be set in the RDS instance parameter group"
 }
 
+variable "rds_start_stop_schedule" {
+  type        = map(map(any))
+  description = "A map whose keys represent RDS instances and whose values define configuration for RDS start/stop schedules"
+}
+
 # ------------------------------------------------------------------------------
 # Vault Variables
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Added module config for RDS start/stop
Added supporting variables for RDS start/stop schedules
Added schedules in Dev and Staging for:
* BCD
* CHD
* CHDATA
* CICS
* WCK

Schedules are set such that the RDS will be stopped after the apps have stopped and started before the apps are started.