### PR TITLE
Add RDS Start/Stop Schedules

### DIFF
--- a/groups/sessions/profiles/heritage-development-eu-west-2/vars
+++ b/groups/sessions/profiles/heritage-development-eu-west-2/vars
@@ -109,3 +109,7 @@ parameter_group_settings = [
       value = "AUTO"
     },
 ]
+
+rds_schedule_enable = true
+rds_start_schedule = "cron(0 5 * * ? *)"
+rds_stop_schedule = "cron(0 21 * * ? *)"

--- a/groups/sessions/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/sessions/profiles/heritage-staging-eu-west-2/vars
@@ -112,3 +112,7 @@ parameter_group_settings = [
       value = "AUTO"
     },
 ]
+
+rds_schedule_enable = true
+rds_start_schedule = "cron(0 5 * * ? *)"
+rds_stop_schedule = "cron(0 21 * * ? *)"

--- a/groups/sessions/rds.tf
+++ b/groups/sessions/rds.tf
@@ -192,3 +192,13 @@ module "sessions_rds" {
     )
   )
 }
+
+module "rds_start_stop_schedule" {
+  source = "git@github.com:companieshouse/terraform-modules//aws/rds_start_stop_schedule?ref=tags/1.0.131"
+
+  rds_schedule_enable = var.rds_schedule_enable
+
+  rds_instance_id     = module.sessions_rds.this_db_instance_id
+  rds_start_schedule  = var.rds_start_schedule
+  rds_stop_schedule   = var.rds_stop_schedule
+}

--- a/groups/sessions/variables.tf
+++ b/groups/sessions/variables.tf
@@ -80,6 +80,24 @@ variable "rds_onpremise_access" {
   default     = []
 }
 
+variable "rds_schedule_enable" {
+  type        = bool
+  description = "Controls whether a start/stop schedule will be created for the RDS instance (true) or not (false)"
+  default     = false
+}
+
+variable "rds_start_schedule" {
+  type        = string
+  description = "The SSM cron expression that defines when the RDS instance will be started"
+  default     = ""
+}
+
+variable "rds_stop_schedule" {
+  type        = string
+  description = "The SSM cron expression that defines when the RDS instance will be stopped"
+  default     = ""
+}
+
 # ------------------------------------------------------------------------------
 # RDS Storage Variables
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Added module config for RDS start/stop
Added supporting variables for RDS start/stop schedules
Added schedules in Dev and Staging

Schedules are set such that the RDS will be stopped after the apps have stopped and started before the apps are started.