### PR TITLE
Refactor SG data-source Lookups & Permit CHIPSDB Access to BCD & CHDATA Live

### DIFF
--- a/groups/heritage-shared-infrastructure/data.tf
+++ b/groups/heritage-shared-infrastructure/data.tf
@@ -19,89 +19,46 @@ data "aws_security_group" "rds_shared" {
   }
 }
 
-data "aws_security_group" "xml_fe_asg" {
+data "aws_security_group" "rds_ingress_bcd" {
+  count = length(var.rds_ingress_groups["bcd"])
   filter {
     name   = "group-name"
-    values = ["sgr-xml-fe-asg*"]
+    values = [var.rds_ingress_groups["bcd"][count.index]]
   }
 }
 
-data "aws_security_group" "xml_fe_tux" {
-  filter {
-    name   = "tag:Name"
-    values = ["xml-frontend-tuxedo-${var.environment}"]
-  }
-}
-
-data "aws_security_group" "xml_bep_asg" {
+data "aws_security_group" "rds_ingress_chd" {
+  count = length(var.rds_ingress_groups["chd"])
   filter {
     name   = "group-name"
-    values = ["sgr-xml-bep-asg*"]
+    values = [var.rds_ingress_groups["chd"][count.index]]
   }
 }
 
-data "aws_security_group" "ewf_fe_asg" {
+data "aws_security_group" "rds_ingress_chdata" {
+  count = length(var.rds_ingress_groups["chdata"])
   filter {
     name   = "group-name"
-    values = ["sgr-ewf-fe-asg*"]
+    values = [var.rds_ingress_groups["chdata"][count.index]]
   }
 }
 
-data "aws_security_group" "ewf_fe_tux" {
-  filter {
-    name   = "tag:Name"
-    values = ["ewf-frontend-tuxedo-${var.environment}"]
-  }
-}
-
-data "aws_security_group" "ewf_bep_asg" {
+data "aws_security_group" "rds_ingress_cics" {
+  count = length(var.rds_ingress_groups["cics"])
   filter {
     name   = "group-name"
-    values = ["sgr-ewf-bep-asg*"]
+    values = [var.rds_ingress_groups["cics"][count.index]]
   }
 }
 
-data "aws_security_group" "adminsites" {
-  filter {
-    name   = "tag:Name"
-    values = ["sgr-admin-sites-asg*"]
-  }
-}
-
-data "aws_security_group" "cics_asg" {
-  filter {
-    name   = "tag:Name"
-    values = ["sgr-cics-asg*"]
-  }
-}
-
-data "aws_security_group" "chd_bep_asg" {
+data "aws_security_group" "rds_ingress_wck" {
+  count = length(var.rds_ingress_groups["wck"])
   filter {
     name   = "group-name"
-    values = ["sgr-chd-bep-asg*"]
+    values = [var.rds_ingress_groups["wck"][count.index]]
   }
 }
 
-data "aws_security_group" "chd_fe_asg" {
-  filter {
-    name   = "group-name"
-    values = ["sgr-chd-fe-asg*"]
-  }
-}
-
-data "aws_security_group" "wck_fe_asg" {
-  filter {
-    name   = "group-name"
-    values = ["sgr-wck-fe-asg*"]
-  }
-}
-
-data "aws_security_group" "wck_bep_asg" {
-  filter {
-    name   = "group-name"
-    values = ["sgr-wck-bep-asg*"]
-  }
-}
 
 data "aws_route53_zone" "private_zone" {
   name         = local.internal_fqdn

--- a/groups/heritage-shared-infrastructure/locals.tf
+++ b/groups/heritage-shared-infrastructure/locals.tf
@@ -16,177 +16,51 @@ locals {
   internal_fqdn = format("%s.%s.aws.internal", split("-", var.aws_account)[1], split("-", var.aws_account)[0])
 
   rds_ingress_from_services = {
-    "bcd" = [
-      {
+    "bcd" = flatten([
+      for sg_data in data.aws_security_group.rds_ingress_bcd : {
         from_port                = 1521
         to_port                  = 1521
         protocol                 = "tcp"
-        description              = "Frontend XML"
-        source_security_group_id = data.aws_security_group.xml_fe_asg.id
-      },
-      {
-        from_port                = 1521
-        to_port                  = 1521
-        protocol                 = "tcp"
-        description              = "Backend XML"
-        source_security_group_id = data.aws_security_group.xml_bep_asg.id
-      },
-      {
-        from_port                = 1521
-        to_port                  = 1521
-        protocol                 = "tcp"
-        description              = "Frontend Tuxedo EWF"
-        source_security_group_id = data.aws_security_group.ewf_fe_tux.id
-      },
-      {
-        from_port                = 1521
-        to_port                  = 1521
-        protocol                 = "tcp"
-        description              = "Frontend Tuxedo XML"
-        source_security_group_id = data.aws_security_group.xml_fe_tux.id
-      },
-      {
-        from_port                = 1521
-        to_port                  = 1521
-        protocol                 = "tcp"
-        description              = "Backend EWF"
-        source_security_group_id = data.aws_security_group.ewf_bep_asg.id
-      },
-      {
-        from_port                = 1521
-        to_port                  = 1521
-        protocol                 = "tcp"
-        description              = "Frontend EWF"
-        source_security_group_id = data.aws_security_group.ewf_fe_asg.id
-      },
-      {
-        from_port                = 1521
-        to_port                  = 1521
-        protocol                 = "tcp"
-        description              = "Admin Sites"
-        source_security_group_id = data.aws_security_group.adminsites.id
+        description              = "Access from ${sg_data.tags.Name}"
+        source_security_group_id = sg_data.id
       }
-    ],
-    "chdata" = [
-      {
+    ])
+    "chdata" = flatten([
+      for sg_data in data.aws_security_group.rds_ingress_chdata : {
         from_port                = 1521
         to_port                  = 1521
         protocol                 = "tcp"
-        description              = "Frontend XML"
-        source_security_group_id = data.aws_security_group.xml_fe_asg.id
-      },
-      {
-        from_port                = 1521
-        to_port                  = 1521
-        protocol                 = "tcp"
-        description              = "Backend XML"
-        source_security_group_id = data.aws_security_group.xml_bep_asg.id
-      },
-      {
-        from_port                = 1521
-        to_port                  = 1521
-        protocol                 = "tcp"
-        description              = "Frontend Tuxedo EWF"
-        source_security_group_id = data.aws_security_group.ewf_fe_tux.id
-      },
-      {
-        from_port                = 1521
-        to_port                  = 1521
-        protocol                 = "tcp"
-        description              = "Frontend Tuxedo XML"
-        source_security_group_id = data.aws_security_group.xml_fe_tux.id
+        description              = "Access from ${sg_data.tags.Name}"
+        source_security_group_id = sg_data.id
       }
-    ],
-    "chd" = [
-      {
+    ])
+    "chd" = flatten([
+      for sg_data in data.aws_security_group.rds_ingress_chd : {
         from_port                = 1521
         to_port                  = 1521
         protocol                 = "tcp"
-        description              = "Frontend EWF"
-        source_security_group_id = data.aws_security_group.ewf_fe_asg.id
-      },
-      {
-        from_port                = 1521
-        to_port                  = 1521
-        protocol                 = "tcp"
-        description              = "Backend EWF"
-        source_security_group_id = data.aws_security_group.ewf_bep_asg.id
-      },
-      {
-        from_port                = 1521
-        to_port                  = 1521
-        protocol                 = "tcp"
-        description              = "Frontend Tuxedo EWF"
-        source_security_group_id = data.aws_security_group.ewf_fe_tux.id
-      },
-      {
-        from_port                = 1521
-        to_port                  = 1521
-        protocol                 = "tcp"
-        description              = "Backend CHD"
-        source_security_group_id = data.aws_security_group.chd_bep_asg.id
-      },
-      {
-        from_port                = 1521
-        to_port                  = 1521
-        protocol                 = "tcp"
-        description              = "Frontend CHD"
-        source_security_group_id = data.aws_security_group.chd_fe_asg.id
-      },
-    ],
-    "wck" = [
-      {
-        from_port                = 1521
-        to_port                  = 1521
-        protocol                 = "tcp"
-        description              = "Frontend EWF"
-        source_security_group_id = data.aws_security_group.ewf_fe_asg.id
-      },
-      {
-        from_port                = 1521
-        to_port                  = 1521
-        protocol                 = "tcp"
-        description              = "Backend EWF"
-        source_security_group_id = data.aws_security_group.ewf_bep_asg.id
-      },
-      {
-        from_port                = 1521
-        to_port                  = 1521
-        protocol                 = "tcp"
-        description              = "Frontend Tuxedo EWF"
-        source_security_group_id = data.aws_security_group.ewf_fe_tux.id
-      },
-      {
-        from_port                = 1521
-        to_port                  = 1521
-        protocol                 = "tcp"
-        description              = "Backend CHD"
-        source_security_group_id = data.aws_security_group.chd_bep_asg.id
-      },
-      {
-        from_port                = 1521
-        to_port                  = 1521
-        protocol                 = "tcp"
-        description              = "Frontend WCK"
-        source_security_group_id = data.aws_security_group.wck_fe_asg.id
-      },
-      {
-        from_port                = 1521
-        to_port                  = 1521
-        protocol                 = "tcp"
-        description              = "Backend WCK"
-        source_security_group_id = data.aws_security_group.wck_bep_asg.id
+        description              = "Access from ${sg_data.tags.Name}"
+        source_security_group_id = sg_data.id
       }
-    ],
-    "cics" = [
-      {
+    ])
+    "cics" = flatten([
+      for sg_data in data.aws_security_group.rds_ingress_cics : {
         from_port                = 1521
         to_port                  = 1521
         protocol                 = "tcp"
-        description              = "CICs App"
-        source_security_group_id = data.aws_security_group.cics_asg.id
+        description              = "Access from ${sg_data.tags.Name}"
+        source_security_group_id = sg_data.id
       }
-    ]
+    ])
+    "wck" = flatten([
+      for sg_data in data.aws_security_group.rds_ingress_wck : {
+        from_port                = 1521
+        to_port                  = 1521
+        protocol                 = "tcp"
+        description              = "Access from ${sg_data.tags.Name}"
+        source_security_group_id = sg_data.id
+      }
+    ])
   }
 
   rds_databases_requiring_app_access = {

--- a/groups/heritage-shared-infrastructure/profiles/heritage-development-eu-west-2/vars
+++ b/groups/heritage-shared-infrastructure/profiles/heritage-development-eu-west-2/vars
@@ -550,6 +550,42 @@ parameter_group_settings = {
   ]
 }
 
+rds_ingress_groups = {
+  bcd = [
+    "sgr-xml-fe-asg*",
+    "sgr-xml-bep-asg*",
+    "ewf-frontend-tuxedo*",
+    "xml-frontend-tuxedo*",
+    "sgr-ewf-bep-asg*",
+    "sgr-ewf-fe-asg*",
+    "sgr-admin-sites-asg*"
+  ],
+  chdata = [
+    "sgr-xml-fe-asg*",
+    "sgr-xml-bep-asg*",
+    "ewf-frontend-tuxedo*",
+    "xml-frontend-tuxedo*"
+  ],
+  chd = [
+    "sgr-ewf-fe-asg*",
+    "sgr-ewf-bep-asg*",
+    "ewf-frontend-tuxedo*",
+    "sgr-chd-bep-asg*",
+    "sgr-chd-fe-asg*"
+  ],
+  cics = [
+    "sgr-cics-asg*"
+  ],
+  wck = [
+    "sgr-ewf-fe-asg*",
+    "sgr-ewf-bep-asg*",
+    "ewf-frontend-tuxedo*",
+    "sgr-chd-bep-asg*",
+    "sgr-wck-fe-asg*",
+    "sgr-wck-bep-asg*"
+  ]
+}
+
 rds_start_stop_schedule = {
   bcd = {
     rds_schedule_enable = true

--- a/groups/heritage-shared-infrastructure/profiles/heritage-live-eu-west-2/vars
+++ b/groups/heritage-shared-infrastructure/profiles/heritage-live-eu-west-2/vars
@@ -554,6 +554,44 @@ parameter_group_settings = {
   ]
 }
 
+rds_ingress_groups = {
+  bcd = [
+    "sgr-xml-fe-asg*",
+    "sgr-xml-bep-asg*",
+    "ewf-frontend-tuxedo*",
+    "xml-frontend-tuxedo*",
+    "sgr-ewf-bep-asg*",
+    "sgr-ewf-fe-asg*",
+    "sgr-admin-sites-asg*",
+    "sgr-chips-oltp-db*",
+    "sgr-chips-rep-db*"
+  ],
+  chdata = [
+    "sgr-xml-fe-asg*",
+    "sgr-xml-bep-asg*",
+    "ewf-frontend-tuxedo*",
+    "xml-frontend-tuxedo*"
+  ],
+  chd = [
+    "sgr-ewf-fe-asg*",
+    "sgr-ewf-bep-asg*",
+    "ewf-frontend-tuxedo*",
+    "sgr-chd-bep-asg*",
+    "sgr-chd-fe-asg*"
+  ],
+  cics = [
+    "sgr-cics-asg*"
+  ],
+  wck = [
+    "sgr-ewf-fe-asg*",
+    "sgr-ewf-bep-asg*",
+    "ewf-frontend-tuxedo*",
+    "sgr-chd-bep-asg*",
+    "sgr-wck-fe-asg*",
+    "sgr-wck-bep-asg*"
+  ]
+}
+
 rds_start_stop_schedule = {
   bcd = {
     rds_schedule_enable = false

--- a/groups/heritage-shared-infrastructure/profiles/heritage-live-eu-west-2/vars
+++ b/groups/heritage-shared-infrastructure/profiles/heritage-live-eu-west-2/vars
@@ -570,7 +570,8 @@ rds_ingress_groups = {
     "sgr-xml-fe-asg*",
     "sgr-xml-bep-asg*",
     "ewf-frontend-tuxedo*",
-    "xml-frontend-tuxedo*"
+    "xml-frontend-tuxedo*",
+    "sgr-chips-rep-db*"
   ],
   chd = [
     "sgr-ewf-fe-asg*",

--- a/groups/heritage-shared-infrastructure/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/heritage-shared-infrastructure/profiles/heritage-staging-eu-west-2/vars
@@ -569,6 +569,42 @@ parameter_group_settings = {
   ],
 }
 
+rds_ingress_groups = {
+  bcd = [
+    "sgr-xml-fe-asg*",
+    "sgr-xml-bep-asg*",
+    "ewf-frontend-tuxedo*",
+    "xml-frontend-tuxedo*",
+    "sgr-ewf-bep-asg*",
+    "sgr-ewf-fe-asg*",
+    "sgr-admin-sites-asg*"
+  ],
+  chdata = [
+    "sgr-xml-fe-asg*",
+    "sgr-xml-bep-asg*",
+    "ewf-frontend-tuxedo*",
+    "xml-frontend-tuxedo*"
+  ],
+  chd = [
+    "sgr-ewf-fe-asg*",
+    "sgr-ewf-bep-asg*",
+    "ewf-frontend-tuxedo*",
+    "sgr-chd-bep-asg*",
+    "sgr-chd-fe-asg*"
+  ],
+  cics = [
+    "sgr-cics-asg*"
+  ],
+  wck = [
+    "sgr-ewf-fe-asg*",
+    "sgr-ewf-bep-asg*",
+    "ewf-frontend-tuxedo*",
+    "sgr-chd-bep-asg*",
+    "sgr-wck-fe-asg*",
+    "sgr-wck-bep-asg*"
+  ]
+}
+
 rds_start_stop_schedule = {
   bcd = {
     rds_schedule_enable = true

--- a/groups/heritage-shared-infrastructure/variables.tf
+++ b/groups/heritage-shared-infrastructure/variables.tf
@@ -45,6 +45,11 @@ variable "rds_databases" {
   type = map
 }
 
+variable "rds_ingress_groups" {
+  type        = map(list(string))
+  description = "A map whose keys represent RDS instances and whose values are lists of strings representing security group filter patterns"
+}
+
 variable "parameter_group_settings" {
   type        = map(list(any))
   description = "A map whose keys represent RDS instances and whose values are a list of parameters that will be set in the RDS instance parameter group"


### PR DESCRIPTION
Refactored security group data-source lookups to be more dynamic, based on a map of lists for each instance.
This removes the need to have conditional statements when specific access is desired in a single environment.
Updated `rds_ingress_from_services` local var to use the dynamic data-sources
Added support vars and populated for each RDS instance in each environment.

Added SG patterns for CHIPSDB access to BCDLIVE and CHDATALIVE