### PR TITLE
Upgrade Live RDS to Oracle 19

### DIFF
--- a/groups/heritage-shared-infrastructure/profiles/heritage-live-eu-west-2/vars
+++ b/groups/heritage-shared-infrastructure/profiles/heritage-live-eu-west-2/vars
@@ -10,13 +10,15 @@ environment = "live"
 
 rds_databases = {
   bcd = {
+    apply_immediately = true
+    allow_major_version_upgrade = true
     instance_class             = "db.m5.xlarge"
     allocated_storage          = 150
     backup_retention_period    = 2
     multi_az                   = true
     engine                     = "oracle-se2"
-    major_engine_version       = "12.1"
-    engine_version             = "12.1"
+    major_engine_version       = "19"
+    engine_version             = "19"
     auto_minor_version_upgrade = true
     license_model              = "license-included"
     rds_maintenance_window     = "Sat:10:00-Sat:13:00"
@@ -46,13 +48,15 @@ rds_databases = {
     ]
   },
   chdata = {
+    apply_immediately = true
+    allow_major_version_upgrade = true
     instance_class             = "db.m5.2xlarge"
     allocated_storage          = 40
     backup_retention_period    = 2
     multi_az                   = true
     engine                     = "oracle-se2"
-    major_engine_version       = "12.1"
-    engine_version             = "12.1"
+    major_engine_version       = "19"
+    engine_version             = "19"
     auto_minor_version_upgrade = true
     license_model              = "license-included"
     rds_maintenance_window     = "Sat:10:00-Sat:13:00"
@@ -81,13 +85,15 @@ rds_databases = {
     ]
   },
   chd = {
+    apply_immediately = true
+    allow_major_version_upgrade = true
     instance_class             = "db.m5.large"
     allocated_storage          = 40
     backup_retention_period    = 14
     multi_az                   = true
     engine                     = "oracle-se2"
-    major_engine_version       = "12.1"
-    engine_version             = "12.1"
+    major_engine_version       = "19"
+    engine_version             = "19"
     auto_minor_version_upgrade = true
     license_model              = "license-included"
     rds_maintenance_window     = "Sat:10:00-Sat:13:00"
@@ -120,13 +126,15 @@ rds_databases = {
     ]
   },
   wck = {
+    apply_immediately = true
+    allow_major_version_upgrade = true
     instance_class             = "db.m5.large"
     allocated_storage          = 50
     backup_retention_period    = 14
     multi_az                   = true
     engine                     = "oracle-se2"
-    major_engine_version       = "12.1"
-    engine_version             = "12.1"
+    major_engine_version       = "19"
+    engine_version             = "19"
     auto_minor_version_upgrade = true
     license_model              = "license-included"
     rds_maintenance_window     = "Sat:10:00-Sat:13:00"
@@ -155,6 +163,8 @@ rds_databases = {
     ]
   },
   cics = {
+    apply_immediately = false
+    allow_major_version_upgrade = false
     instance_class             = "db.m5.large"
     allocated_storage          = 30
     backup_retention_period    = 14
@@ -199,12 +209,8 @@ parameter_group_settings = {
       value = "6"
     },
     {
-      name  = "sec_case_sensitive_logon"
-      value = "TRUE"
-    },
-    {
       name         = "compatible"
-      value        = "12.1.0.2.0"
+      value        = "19.0.0"
       apply_method = "pending-reboot"
     },      
     {
@@ -251,6 +257,14 @@ parameter_group_settings = {
       apply_method = "pending-reboot"
     },
     {
+      name  = "sqlnetora.sqlnet.allowed_logon_version_client"
+      value = "10"
+    },
+    {
+      name  = "sqlnetora.sqlnet.allowed_logon_version_server"
+      value = "10"
+    },
+    {
       name         = "timed_statistics"
       value        = "TRUE"
       apply_method = "pending-reboot"
@@ -270,12 +284,8 @@ parameter_group_settings = {
       value = "6"
     },
     {
-      name  = "sec_case_sensitive_logon"
-      value = "TRUE"
-    },
-    {
       name         = "compatible"
-      value        = "12.1.0.2.0"
+      value        = "19.0.0"
       apply_method = "pending-reboot"
     },
     {
@@ -320,6 +330,14 @@ parameter_group_settings = {
       name         = "sessions"
       value        = "6720"
       apply_method = "pending-reboot"
+    },
+    {
+      name  = "sqlnetora.sqlnet.allowed_logon_version_client"
+      value = "10"
+    },
+    {
+      name  = "sqlnetora.sqlnet.allowed_logon_version_server"
+      value = "10"
     },
     {
       name         = "timed_statistics"
@@ -341,12 +359,8 @@ parameter_group_settings = {
       value = "6"
     },
     {
-      name  = "sec_case_sensitive_logon"
-      value = "TRUE"
-    },
-    {
       name         = "compatible"
-      value        = "12.1.0.2.0"
+      value        = "19.0.0"
       apply_method = "pending-reboot"
     },
     {
@@ -391,6 +405,14 @@ parameter_group_settings = {
       name         = "sessions"
       value        = "6720"
       apply_method = "pending-reboot"
+    },
+    {
+      name  = "sqlnetora.sqlnet.allowed_logon_version_client"
+      value = "10"
+    },
+    {
+      name  = "sqlnetora.sqlnet.allowed_logon_version_server"
+      value = "10"
     },
     {
       name         = "timed_statistics"
@@ -412,12 +434,8 @@ parameter_group_settings = {
       value = "6"
     },
     {
-      name  = "sec_case_sensitive_logon"
-      value = "TRUE"
-    },
-    {
       name         = "compatible"
-      value        = "12.1.0.2.0"
+      value        = "19.0.0"
       apply_method = "pending-reboot"
     },
     {
@@ -462,6 +480,14 @@ parameter_group_settings = {
       name         = "sessions"
       value        = "6720"
       apply_method = "pending-reboot"
+    },
+    {
+      name  = "sqlnetora.sqlnet.allowed_logon_version_client"
+      value = "10"
+    },
+    {
+      name  = "sqlnetora.sqlnet.allowed_logon_version_server"
+      value = "10"
     },
     {
       name         = "timed_statistics"

--- a/groups/heritage-shared-infrastructure/rds.tf
+++ b/groups/heritage-shared-infrastructure/rds.tf
@@ -56,6 +56,9 @@ module "rds" {
   create_db_parameter_group = "true"
   create_db_subnet_group    = "true"
 
+  apply_immediately = lookup(each.value, "apply_immediately")
+  allow_major_version_upgrade = lookup(each.value, "allow_major_version_upgrade")
+
   identifier                 = join("-", ["rds", each.key, var.environment, "001"])
   engine                     = lookup(each.value, "engine", "oracle-se2")
   major_engine_version       = lookup(each.value, "major_engine_version", "12.1")

--- a/groups/sessions/profiles/heritage-live-eu-west-2/vars
+++ b/groups/sessions/profiles/heritage-live-eu-west-2/vars
@@ -21,8 +21,8 @@ rds_maintenance_window  = "Sat:10:00-Sat:13:00"
 rds_backup_window       = "03:00-06:00"
 
 # RDS Engine settings
-major_engine_version       = "12.1"
-engine_version             = "12.1"
+major_engine_version       = "19"
+engine_version             = "19"
 license_model              = "license-included"
 auto_minor_version_upgrade = true
 
@@ -55,12 +55,8 @@ parameter_group_settings = [
       value = "6"
     },
     {
-      name  = "sec_case_sensitive_logon"
-      value = "TRUE"
-    },
-    {
       name         = "compatible"
-      value        = "12.1.0.2.0"
+      value        = "19.0.0"
       apply_method = "pending-reboot"
     },      
     {
@@ -105,6 +101,14 @@ parameter_group_settings = [
       name         = "sessions"
       value        = "6720"
       apply_method = "pending-reboot"
+    },
+    {
+      name  = "sqlnetora.sqlnet.allowed_logon_version_client"
+      value = "10"
+    },
+    {
+      name  = "sqlnetora.sqlnet.allowed_logon_version_server"
+      value = "10"
     },
     {
       name         = "timed_statistics"

--- a/groups/sessions/rds.tf
+++ b/groups/sessions/rds.tf
@@ -100,6 +100,9 @@ module "sessions_rds" {
   create_db_parameter_group = "true"
   create_db_subnet_group    = "true"
 
+  apply_immediately = true
+  allow_major_version_upgrade = true
+
   identifier                 = join("-", ["rds", var.identifier, var.environment, "001"])
   engine                     = "oracle-se2"
   major_engine_version       = var.major_engine_version

--- a/groups/sessions/rds.tf
+++ b/groups/sessions/rds.tf
@@ -100,9 +100,6 @@ module "sessions_rds" {
   create_db_parameter_group = "true"
   create_db_subnet_group    = "true"
 
-  apply_immediately = true
-  allow_major_version_upgrade = true
-
   identifier                 = join("-", ["rds", var.identifier, var.environment, "001"])
   engine                     = "oracle-se2"
   major_engine_version       = var.major_engine_version


### PR DESCRIPTION
Updated parameters to upgrade BCD, CHD, CHDATA, SESSIONS and WCK to Oracle 19