### PR TITLE
Add RDS CloudWatch Alarms

### DIFF
--- a/groups/heritage-shared-infrastructure/profiles/heritage-development-eu-west-2/vars
+++ b/groups/heritage-shared-infrastructure/profiles/heritage-development-eu-west-2/vars
@@ -629,3 +629,31 @@ rds_start_stop_schedule = {
     rds_stop_schedule = "cron(0 21 * * ? *)"
   }
 }
+
+rds_cloudwatch_alarms = {
+  bcd = {
+    alarm_actions_enabled = false
+    alarm_topic_name = ""
+    alarm_topic_name_ooh = ""
+  },
+  chd = {
+    alarm_actions_enabled = false
+    alarm_topic_name = ""
+    alarm_topic_name_ooh = ""
+  },
+  chdata = {
+    alarm_actions_enabled = false
+    alarm_topic_name = ""
+    alarm_topic_name_ooh = ""
+  },
+  cics = {
+    alarm_actions_enabled = false
+    alarm_topic_name = ""
+    alarm_topic_name_ooh = ""
+  },
+  wck = {
+    alarm_actions_enabled = false
+    alarm_topic_name = ""
+    alarm_topic_name_ooh = ""
+  }
+}

--- a/groups/heritage-shared-infrastructure/profiles/heritage-live-eu-west-2/vars
+++ b/groups/heritage-shared-infrastructure/profiles/heritage-live-eu-west-2/vars
@@ -637,3 +637,31 @@ rds_start_stop_schedule = {
     rds_stop_schedule = ""
   }
 }
+
+rds_cloudwatch_alarms = {
+  bcd = {
+    alarm_actions_enabled = false
+    alarm_topic_name = "Email_Alerts"
+    alarm_topic_name_ooh = "Phonecall_Alerts"
+  },
+  chd = {
+    alarm_actions_enabled = false
+    alarm_topic_name = "Email_Alerts"
+    alarm_topic_name_ooh = "Phonecall_Alerts"
+  },
+  chdata = {
+    alarm_actions_enabled = false
+    alarm_topic_name = "Email_Alerts"
+    alarm_topic_name_ooh = "Phonecall_Alerts"
+  },
+  cics = {
+    alarm_actions_enabled = false
+    alarm_topic_name = "Email_Alerts"
+    alarm_topic_name_ooh = "Phonecall_Alerts"
+  },
+  wck = {
+    alarm_actions_enabled = false
+    alarm_topic_name = "Email_Alerts"
+    alarm_topic_name_ooh = "Phonecall_Alerts"
+  }
+}

--- a/groups/heritage-shared-infrastructure/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/heritage-shared-infrastructure/profiles/heritage-staging-eu-west-2/vars
@@ -636,3 +636,31 @@ rds_start_stop_schedule = {
     rds_stop_schedule = "cron(0 21 * * ? *)"
   }
 }
+
+rds_cloudwatch_alarms = {
+  bcd = {
+    alarm_actions_enabled = false
+    alarm_topic_name = ""
+    alarm_topic_name_ooh = ""
+  },
+  chd = {
+    alarm_actions_enabled = false
+    alarm_topic_name = ""
+    alarm_topic_name_ooh = ""
+  },
+  chdata = {
+    alarm_actions_enabled = false
+    alarm_topic_name = ""
+    alarm_topic_name_ooh = ""
+  },
+  cics = {
+    alarm_actions_enabled = false
+    alarm_topic_name = ""
+    alarm_topic_name_ooh = ""
+  },
+  wck = {
+    alarm_actions_enabled = false
+    alarm_topic_name = ""
+    alarm_topic_name_ooh = ""
+  }
+}

--- a/groups/heritage-shared-infrastructure/rds.tf
+++ b/groups/heritage-shared-infrastructure/rds.tf
@@ -153,3 +153,15 @@ module "rds_start_stop_schedule" {
   rds_start_schedule  = lookup(each.value, "rds_start_schedule")
   rds_stop_schedule   = lookup(each.value, "rds_stop_schedule")
 }
+
+module "rds_cloudwatch_alarms" {
+  source = "git@github.com:companieshouse/terraform-modules//aws/rds_cloudwatch_alarms?ref=tags/1.0.167"
+
+  for_each = var.rds_cloudwatch_alarms
+
+  rds_instance_id        = module.rds[each.key].this_db_instance_id
+  rds_instance_shortname = upper(each.key)
+  alarm_actions_enabled  = lookup(each.value, "alarm_actions_enabled")
+  alarm_topic_name       = lookup(each.value, "alarm_topic_name")
+  alarm_topic_name_ooh   = lookup(each.value, "alarm_topic_name_ooh")
+}

--- a/groups/heritage-shared-infrastructure/variables.tf
+++ b/groups/heritage-shared-infrastructure/variables.tf
@@ -60,6 +60,11 @@ variable "rds_start_stop_schedule" {
   description = "A map whose keys represent RDS instances and whose values define configuration for RDS start/stop schedules"
 }
 
+variable "rds_cloudwatch_alarms" {
+  type        = map(map(any))
+  description = "A map whose keys represent RDS instances and whose values define RDS CloudWatch Alarms configuration"
+}
+
 # ------------------------------------------------------------------------------
 # Vault Variables
 # ------------------------------------------------------------------------------

--- a/groups/sessions/profiles/heritage-development-eu-west-2/vars
+++ b/groups/sessions/profiles/heritage-development-eu-west-2/vars
@@ -117,3 +117,8 @@ parameter_group_settings = [
 rds_schedule_enable = true
 rds_start_schedule = "cron(0 5 * * ? *)"
 rds_stop_schedule = "cron(0 21 * * ? *)"
+
+## CloudWatch Alarms
+alarm_actions_enabled  = false
+alarm_topic_name       = ""
+alarm_topic_name_ooh   = ""

--- a/groups/sessions/profiles/heritage-live-eu-west-2/vars
+++ b/groups/sessions/profiles/heritage-live-eu-west-2/vars
@@ -124,3 +124,8 @@ parameter_group_settings = [
       value = "AUTO"
     },
 ]
+
+## CloudWatch Alarms
+alarm_actions_enabled  = false
+alarm_topic_name       = "Email_Alerts"
+alarm_topic_name_ooh   = "Phonecall_Alerts"

--- a/groups/sessions/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/sessions/profiles/heritage-staging-eu-west-2/vars
@@ -120,3 +120,8 @@ parameter_group_settings = [
 rds_schedule_enable = true
 rds_start_schedule = "cron(0 5 * * ? *)"
 rds_stop_schedule = "cron(0 21 * * ? *)"
+
+## CloudWatch Alarms
+alarm_actions_enabled  = false
+alarm_topic_name       = ""
+alarm_topic_name_ooh   = ""

--- a/groups/sessions/rds.tf
+++ b/groups/sessions/rds.tf
@@ -202,3 +202,13 @@ module "rds_start_stop_schedule" {
   rds_start_schedule  = var.rds_start_schedule
   rds_stop_schedule   = var.rds_stop_schedule
 }
+
+module "rds_cloudwatch_alarms" {
+  source = "git@github.com:companieshouse/terraform-modules//aws/rds_cloudwatch_alarms?ref=tags/1.0.167"
+
+  rds_instance_id        = module.sessions_rds.this_db_instance_id
+  rds_instance_shortname = upper(var.name)
+  alarm_actions_enabled  = var.alarm_actions_enabled
+  alarm_topic_name       = var.alarm_topic_name
+  alarm_topic_name_ooh   = var.alarm_topic_name_ooh
+}

--- a/groups/sessions/variables.tf
+++ b/groups/sessions/variables.tf
@@ -102,7 +102,7 @@ variable "rds_stop_schedule" {
 # RDS CloudWatch Alarm Variables
 # ------------------------------------------------------------------------------
 variable "alarm_actions_enabled" {
-  type        = string
+  type        = bool
   description = "Defines whether SNS-based alarm actions should be enabled (true) or not (false) for alarms"
 }
 

--- a/groups/sessions/variables.tf
+++ b/groups/sessions/variables.tf
@@ -99,6 +99,24 @@ variable "rds_stop_schedule" {
 }
 
 # ------------------------------------------------------------------------------
+# RDS CloudWatch Alarm Variables
+# ------------------------------------------------------------------------------
+variable "alarm_actions_enabled" {
+  type        = string
+  description = "Defines whether SNS-based alarm actions should be enabled (true) or not (false) for alarms"
+}
+
+variable "alarm_topic_name" {
+  type        = string
+  description = "The name of the SNS topic to use for in-hours alarm notifications and clear notifications"
+}
+
+variable "alarm_topic_name_ooh" {
+  type        = string
+  description = "The name of the SNS topic to use for OOH alarm notifications"
+}
+
+# ------------------------------------------------------------------------------
 # RDS Storage Variables
 # ------------------------------------------------------------------------------
 variable "storage_type" {


### PR DESCRIPTION
Added module and supporting config to deploy standard RDS CloudWatch alarms
alarm_actions currently disabled to prevent notification spam while alarms settle after creation