### PR TITLE
Update Oracle Alarms

### DIFF
--- a/groups/heritage-shared-infrastructure/rds.tf
+++ b/groups/heritage-shared-infrastructure/rds.tf
@@ -155,13 +155,14 @@ module "rds_start_stop_schedule" {
 }
 
 module "rds_cloudwatch_alarms" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/rds_cloudwatch_alarms?ref=tags/1.0.167"
+  source = "git@github.com:companieshouse/terraform-modules//aws/oracledb_cloudwatch_alarms?ref=tags/1.0.173"
 
   for_each = var.rds_cloudwatch_alarms
 
-  rds_instance_id        = module.rds[each.key].this_db_instance_id
-  rds_instance_shortname = upper(each.key)
+  db_instance_id         = module.rds[each.key].this_db_instance_id
+  db_instance_shortname  = upper(each.key)
   alarm_actions_enabled  = lookup(each.value, "alarm_actions_enabled")
+  alarm_name_prefix      = "Oracle RDS"
   alarm_topic_name       = lookup(each.value, "alarm_topic_name")
   alarm_topic_name_ooh   = lookup(each.value, "alarm_topic_name_ooh")
 }

--- a/groups/sessions/rds.tf
+++ b/groups/sessions/rds.tf
@@ -204,11 +204,12 @@ module "rds_start_stop_schedule" {
 }
 
 module "rds_cloudwatch_alarms" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/rds_cloudwatch_alarms?ref=tags/1.0.167"
+  source = "git@github.com:companieshouse/terraform-modules//aws/oracledb_cloudwatch_alarms?ref=tags/1.0.173"
 
-  rds_instance_id        = module.sessions_rds.this_db_instance_id
-  rds_instance_shortname = upper(var.name)
+  db_instance_id         = module.sessions_rds.this_db_instance_id
+  db_instance_shortname  = upper(var.name)
   alarm_actions_enabled  = var.alarm_actions_enabled
+  alarm_name_prefix      = "Oracle RDS"
   alarm_topic_name       = var.alarm_topic_name
   alarm_topic_name_ooh   = var.alarm_topic_name_ooh
 }


### PR DESCRIPTION
Updated existing RDS alarms module to use updated terraform module path and version
Updated variable names to match updated module requirements
Set `alarm_name_prefix` appropriately