### PR TITLE
Allow BIBUSOBJ access to CICS RDS

### DIFF
--- a/groups/heritage-shared-infrastructure/profiles/heritage-live-eu-west-2/vars
+++ b/groups/heritage-shared-infrastructure/profiles/heritage-live-eu-west-2/vars
@@ -598,7 +598,8 @@ rds_ingress_groups = {
     "sgr-chd-fe-asg*"
   ],
   cics = [
-    "sgr-cics-asg*"
+    "sgr-cics-asg*",
+    "sgr-windows-workloads-bus-obj-1-server*"
   ],
   wck = [
     "sgr-ewf-fe-asg*",


### PR DESCRIPTION
Added Security Group pattern to permit RDS access to CICS from BIBUSOBJ

Resolves: INC0361606