### PR TITLE
Move JVM option into profile vars to allow it to be removed for CICs only

### DIFF
--- a/groups/heritage-shared-infrastructure/profiles/heritage-development-eu-west-2/vars
+++ b/groups/heritage-shared-infrastructure/profiles/heritage-development-eu-west-2/vars
@@ -43,6 +43,9 @@ rds_databases = {
           },
         ]
       },
+      {
+        option_name = "JVM"
+      }
     ]
   },
   chdata = {
@@ -78,6 +81,9 @@ rds_databases = {
           },
         ]
       },
+      {
+        option_name = "JVM"
+      }
     ]
   },
   chd = {
@@ -117,6 +123,9 @@ rds_databases = {
           },
         ]
       },
+      {
+        option_name = "JVM"
+      }
     ]
   },
   wck = {
@@ -152,6 +161,9 @@ rds_databases = {
           },
         ]
       },
+      {
+        option_name = "JVM"
+      }
     ]
   },
   cics = {

--- a/groups/heritage-shared-infrastructure/profiles/heritage-live-eu-west-2/vars
+++ b/groups/heritage-shared-infrastructure/profiles/heritage-live-eu-west-2/vars
@@ -43,6 +43,9 @@ rds_databases = {
           },
         ]
       },
+      {
+        option_name = "JVM"
+      }
     ]
   },
   chdata = {
@@ -78,6 +81,9 @@ rds_databases = {
           },
         ]
       },
+      {
+        option_name = "JVM"
+      }
     ]
   },
   chd = {
@@ -117,6 +123,9 @@ rds_databases = {
           },
         ]
       },
+      {
+        option_name = "JVM"
+      }
     ]
   },
   wck = {
@@ -152,6 +161,9 @@ rds_databases = {
           },
         ]
       },
+      {
+        option_name = "JVM"
+      }
     ]
   },
   cics = {

--- a/groups/heritage-shared-infrastructure/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/heritage-shared-infrastructure/profiles/heritage-staging-eu-west-2/vars
@@ -42,6 +42,9 @@ rds_databases = {
           },
         ]
       },
+      {
+        option_name = "JVM"
+      }
     ]
   },
   chdata = {
@@ -77,6 +80,9 @@ rds_databases = {
           },
         ]
       },
+      {
+        option_name = "JVM"
+      }
     ]
   },
   chd = {
@@ -116,6 +122,9 @@ rds_databases = {
           },
         ]
       },
+      {
+        option_name = "JVM"
+      }
     ]
   },
   wck = {
@@ -151,6 +160,9 @@ rds_databases = {
           },
         ]
       },
+      {
+        option_name = "JVM"
+      }
     ]
   },
   cics = {

--- a/groups/heritage-shared-infrastructure/rds.tf
+++ b/groups/heritage-shared-infrastructure/rds.tf
@@ -114,9 +114,6 @@ module "rds" {
       vpc_security_group_memberships = [module.rds_security_group[each.key].this_security_group_id]
     },
     {
-      option_name = "JVM"
-    },
-    {
       option_name = "SQLT"
       version     = "2018-07-25.v1"
       option_settings = [


### PR DESCRIPTION
This removes the JVM option from the CICs RDS instance, as it is not possible to turn off automatic application of minor upgrades with that option present. We are not using any Java Oracle features on the DB, so it is not required.

Resolves:
https://companieshouse.atlassian.net/browse/SUP-1106
