### PR TITLE
Use Administration Prefix List

### DIFF
--- a/groups/heritage-shared-infrastructure/data.tf
+++ b/groups/heritage-shared-infrastructure/data.tf
@@ -97,6 +97,6 @@ data "vault_generic_secret" "fes_rds" {
   path = "applications/${var.aws_profile}/fes/rds"
 }
 
-data "vault_generic_secret" "internal_cidrs" {
-  path = "aws-accounts/network/internal_cidr_ranges"
+data "aws_ec2_managed_prefix_list" "administration" {
+  name = "administration-cidr-ranges"
 }

--- a/groups/heritage-shared-infrastructure/locals.tf
+++ b/groups/heritage-shared-infrastructure/locals.tf
@@ -2,8 +2,6 @@
 # Locals
 # ------------------------------------------------------------------------
 locals {
-  admin_cidrs = values(data.vault_generic_secret.internal_cidrs.data)
-
   rds_data = {
     bcd    = data.vault_generic_secret.bcd_rds.data
     chdata = data.vault_generic_secret.chdata_rds.data

--- a/groups/heritage-shared-infrastructure/profiles/heritage-development-eu-west-2/vars
+++ b/groups/heritage-shared-infrastructure/profiles/heritage-development-eu-west-2/vars
@@ -28,10 +28,6 @@ rds_databases = {
           "listener",
           "trace"
     ],
-    rds_onpremise_access = [
-      "192.168.90.0/24",
-      "192.168.70.0/24"
-    ]
     rds_app_access = []
     per_instance_options = [
       {
@@ -66,10 +62,6 @@ rds_databases = {
           "listener",
           "trace"
     ],
-    rds_onpremise_access = [
-      "192.168.90.0/24",
-      "192.168.70.0/24"
-    ]
     rds_app_access = []
     per_instance_options = [
       {
@@ -104,10 +96,6 @@ rds_databases = {
           "listener",
           "trace"
     ],
-    rds_onpremise_access = [
-      "192.168.90.0/24",
-      "192.168.70.0/24"
-    ]
     rds_app_access = [
       "10.75.40.0/21",
       "10.75.80.0/21",
@@ -146,10 +134,6 @@ rds_databases = {
           "listener",
           "trace"
     ],
-    rds_onpremise_access = [
-      "192.168.90.0/24",
-      "192.168.70.0/24"
-    ]
     rds_app_access = []
     per_instance_options = [
       {
@@ -184,10 +168,6 @@ rds_databases = {
           "listener",
           "trace"
     ],
-    rds_onpremise_access = [
-      "192.168.90.0/24",
-      "192.168.70.0/24"
-    ]
     rds_app_access = []
     per_instance_options = [
       {

--- a/groups/heritage-shared-infrastructure/profiles/heritage-live-eu-west-2/vars
+++ b/groups/heritage-shared-infrastructure/profiles/heritage-live-eu-west-2/vars
@@ -27,11 +27,6 @@ rds_databases = {
           "listener",
           "trace"
     ],
-    rds_onpremise_access = [
-      "192.168.90.0/24",
-      "192.168.70.0/24",
-      "192.168.60.0/24"
-    ]
     rds_app_access = []
     per_instance_options = [
       {
@@ -66,10 +61,6 @@ rds_databases = {
           "listener",
           "trace"
     ],
-    rds_onpremise_access = [
-      "192.168.90.0/24",
-      "192.168.70.0/24"
-    ]
     rds_app_access = []
     per_instance_options = [
       {
@@ -104,10 +95,6 @@ rds_databases = {
           "listener",
           "trace"
     ],
-    rds_onpremise_access = [
-      "192.168.90.0/24",
-      "192.168.70.0/24"
-    ]
     rds_app_access = [
       "10.55.2.0/24",
       "10.55.66.0/24",
@@ -146,10 +133,6 @@ rds_databases = {
           "listener",
           "trace"
     ],
-    rds_onpremise_access = [
-      "192.168.90.0/24",
-      "192.168.70.0/24"
-    ]
     rds_app_access = []
     per_instance_options = [
       {
@@ -184,10 +167,6 @@ rds_databases = {
           "listener",
           "trace"
     ],
-    rds_onpremise_access = [
-      "192.168.90.0/24",
-      "192.168.70.0/24"
-    ]
     rds_app_access = []
     per_instance_options = [
       {

--- a/groups/heritage-shared-infrastructure/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/heritage-shared-infrastructure/profiles/heritage-staging-eu-west-2/vars
@@ -27,10 +27,6 @@ rds_databases = {
           "listener",
           "trace"
     ],
-    rds_onpremise_access = [
-      "192.168.90.0/24",
-      "192.168.70.0/24"
-    ]
     rds_app_access = []
     per_instance_options = [
       {
@@ -65,10 +61,6 @@ rds_databases = {
           "listener",
           "trace"
     ],
-    rds_onpremise_access = [
-      "192.168.90.0/24",
-      "192.168.70.0/24"
-    ]
     rds_app_access = []
     per_instance_options = [
       {
@@ -103,10 +95,6 @@ rds_databases = {
           "listener",
           "trace"
     ],
-    rds_onpremise_access = [
-      "192.168.90.0/24",
-      "192.168.70.0/24"
-    ]
     rds_app_access = [
       "10.65.2.0/24",
       "10.65.66.0/24",
@@ -145,10 +133,6 @@ rds_databases = {
           "listener",
           "trace"
     ],
-    rds_onpremise_access = [
-      "192.168.90.0/24",
-      "192.168.70.0/24"
-    ]
     rds_app_access = []
     per_instance_options = [
       {
@@ -183,10 +167,6 @@ rds_databases = {
           "listener",
           "trace"
     ],
-    rds_onpremise_access = [
-      "192.168.90.0/24",
-      "192.168.70.0/24"
-    ]
     rds_app_access = []
     per_instance_options = [
       {

--- a/groups/heritage-shared-infrastructure/rds.tf
+++ b/groups/heritage-shared-infrastructure/rds.tf
@@ -45,7 +45,7 @@ module "rds_app_security_group" {
   egress_rules = ["all-all"]
 }
 
-module "rds_service_security_group" {
+module "rds_security_group_services" {
   for_each = var.rds_databases
 
   source  = "terraform-aws-modules/security-group/aws"
@@ -112,6 +112,7 @@ module "rds" {
   # RDS Security Group
   vpc_security_group_ids = flatten([
     module.rds_security_group[each.key].this_security_group_id,
+    module.rds_security_group_services[each.key].this_security_group_id,
     data.aws_security_group.rds_shared.id,
     [for key, value in module.rds_app_security_group : value.this_security_group_id if key == each.key],
   ])

--- a/groups/sessions/data.tf
+++ b/groups/sessions/data.tf
@@ -19,59 +19,11 @@ data "aws_security_group" "rds_shared" {
   }
 }
 
-data "aws_security_group" "ewf_fe_asg" {
+data "aws_security_group" "rds_ingress" {
+  count = length(var.rds_ingress_groups)
   filter {
     name   = "group-name"
-    values = ["sgr-ewf-fe-asg*"]
-  }
-}
-
-data "aws_security_group" "ewf_bep_asg" {
-  filter {
-    name   = "group-name"
-    values = ["sgr-ewf-bep-asg*"]
-  }
-}
-
-data "aws_security_group" "adminsites" {
-  filter {
-    name   = "tag:Name"
-    values = ["sgr-admin-sites-asg*"]
-  }
-}
-
-data "aws_security_group" "chd_bep_asg" {
-  filter {
-    name   = "group-name"
-    values = ["sgr-chd-bep-asg*"]
-  }
-}
-
-data "aws_security_group" "chd_fe_asg" {
-  filter {
-    name   = "group-name"
-    values = ["sgr-chd-fe-asg*"]
-  }
-}
-
-data "aws_security_group" "ceu_bep_asg" {
-  filter {
-    name   = "group-name"
-    values = ["sgr-ceu-bep-asg*"]
-  }
-}
-
-data "aws_security_group" "wck_fe_asg" {
-  filter {
-    name   = "group-name"
-    values = ["sgr-wck-fe-asg*"]
-  }
-}
-
-data "aws_security_group" "wck_bep_asg" {
-  filter {
-    name   = "group-name"
-    values = ["sgr-wck-bep-asg*"]
+    values = [var.rds_ingress_groups[count.index]]
   }
 }
 
@@ -96,8 +48,8 @@ data "vault_generic_secret" "sess_rds" {
   path = "applications/${var.aws_profile}/sess/rds"
 }
 
-data "vault_generic_secret" "internal_cidrs" {
-  path = "aws-accounts/network/internal_cidr_ranges"
+data "aws_ec2_managed_prefix_list" "administration" {
+  name = "administration-cidr-ranges"
 }
 
 data "vault_generic_secret" "ceu_fe_outputs" {

--- a/groups/sessions/locals.tf
+++ b/groups/sessions/locals.tf
@@ -2,13 +2,22 @@
 # Locals
 # ------------------------------------------------------------------------
 locals {
-  admin_cidrs   = values(data.vault_generic_secret.internal_cidrs.data)
   sess_rds_data = data.vault_generic_secret.sess_rds.data
   accountIds    = data.vault_generic_secret.account_ids.data
 
   internal_fqdn = format("%s.%s.aws.internal", split("-", var.aws_account)[1], split("-", var.aws_account)[0])
 
   ceu_fe_subnet_cidrs = jsondecode(data.vault_generic_secret.ceu_fe_outputs.data["ceu-frontend-web-subnets-cidrs"])
+
+  rds_ingress_from_services = flatten([
+    for sg_data in data.aws_security_group.rds_ingress : {
+      from_port                = 1521
+      to_port                  = 1521
+      protocol                 = "tcp"
+      description              = "Access from ${sg_data.tags.Name}"
+      source_security_group_id = sg_data.id
+    }
+  ])
 
   default_tags = {
     Terraform = "true"

--- a/groups/sessions/profiles/heritage-development-eu-west-2/vars
+++ b/groups/sessions/profiles/heritage-development-eu-west-2/vars
@@ -114,6 +114,17 @@ parameter_group_settings = [
     },
 ]
 
+rds_ingress_groups = [
+  "sgr-ewf-fe-asg*",
+  "sgr-ewf-bep-asg*",
+  "sgr-admin-sites-asg*",
+  "sgr-chd-bep-asg*",
+  "sgr-chd-fe-asg*",
+  "sgr-ceu-bep-asg*",
+  "sgr-wck-fe-asg*",
+  "sgr-wck-bep-asg*"
+]
+
 rds_schedule_enable = true
 rds_start_schedule = "cron(0 5 * * ? *)"
 rds_stop_schedule = "cron(0 21 * * ? *)"

--- a/groups/sessions/profiles/heritage-live-eu-west-2/vars
+++ b/groups/sessions/profiles/heritage-live-eu-west-2/vars
@@ -125,6 +125,17 @@ parameter_group_settings = [
     },
 ]
 
+rds_ingress_groups = [
+  "sgr-ewf-fe-asg*",
+  "sgr-ewf-bep-asg*",
+  "sgr-admin-sites-asg*",
+  "sgr-chd-bep-asg*",
+  "sgr-chd-fe-asg*",
+  "sgr-ceu-bep-asg*",
+  "sgr-wck-fe-asg*",
+  "sgr-wck-bep-asg*"
+]
+
 ## CloudWatch Alarms
 alarm_actions_enabled  = true
 alarm_topic_name       = "Email_Alerts"

--- a/groups/sessions/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/sessions/profiles/heritage-staging-eu-west-2/vars
@@ -117,6 +117,17 @@ parameter_group_settings = [
     },
 ]
 
+rds_ingress_groups = [
+  "sgr-ewf-fe-asg*",
+  "sgr-ewf-bep-asg*",
+  "sgr-admin-sites-asg*",
+  "sgr-chd-bep-asg*",
+  "sgr-chd-fe-asg*",
+  "sgr-ceu-bep-asg*",
+  "sgr-wck-fe-asg*",
+  "sgr-wck-bep-asg*"
+]
+
 rds_schedule_enable = true
 rds_start_schedule = "cron(0 5 * * ? *)"
 rds_stop_schedule = "cron(0 21 * * ? *)"

--- a/groups/sessions/variables.tf
+++ b/groups/sessions/variables.tf
@@ -80,6 +80,12 @@ variable "rds_onpremise_access" {
   default     = []
 }
 
+variable "rds_ingress_groups" {
+  type        = list(string)
+  description = "A list of security group name patterns that will be allowed access to RDS"
+  default     = []
+}
+
 variable "rds_schedule_enable" {
   type        = bool
   description = "Controls whether a start/stop schedule will be created for the RDS instance (true) or not (false)"


### PR DESCRIPTION
Updates security group config to utilise a Managed Prefix List to define administrative access, rather that pulling data from vault. This will allow for safer and easier future updates to administrative access.

## heritage-shared-infrastructure
Removed vault data lookup and replaced with prefix list data lookup
Removed `admin_cidrs` local
Removed now-deprecated object attribute from vars
Restructured RDS security groups for use with the prefix list
Added new security group specific to service access to prevent unwanted inheritance of the prefix list

## sessions
Migrated from static SG lookups to dynamic list-based method
Added local to construct the necessary SG data
Added SG pattern lists to vars
Added prefix list lookup
Added dedicated SG for service ingress
Amended existing SG to use prefix list