### PR TITLE
Per-profile RDS options, disable JVM in staging

### DIFF
--- a/groups/heritage-shared-infrastructure/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/heritage-shared-infrastructure/profiles/heritage-staging-eu-west-2/vars
@@ -17,7 +17,7 @@ rds_databases = {
     engine                     = "oracle-se2"
     major_engine_version       = "19"
     engine_version             = "19"
-    auto_minor_version_upgrade = true
+    auto_minor_version_upgrade = false
     license_model              = "license-included"
     rds_maintenance_window     = "Wed:00:00-Wed:03:00"
     rds_backup_window          = "03:00-06:00"
@@ -42,9 +42,6 @@ rds_databases = {
           },
         ]
       },
-      {
-        option_name = "JVM"
-      }
     ]
   },
   chdata = {
@@ -55,7 +52,7 @@ rds_databases = {
     engine                     = "oracle-se2"
     major_engine_version       = "19"
     engine_version             = "19"
-    auto_minor_version_upgrade = true
+    auto_minor_version_upgrade = false
     license_model              = "license-included"
     rds_maintenance_window     = "Wed:00:00-Wed:03:00"
     rds_backup_window          = "03:00-06:00"
@@ -80,9 +77,6 @@ rds_databases = {
           },
         ]
       },
-      {
-        option_name = "JVM"
-      }
     ]
   },
   chd = {
@@ -93,7 +87,7 @@ rds_databases = {
     engine                     = "oracle-se2"
     major_engine_version       = "19"
     engine_version             = "19"
-    auto_minor_version_upgrade = true
+    auto_minor_version_upgrade = false
     license_model              = "license-included"
     rds_maintenance_window     = "Wed:00:00-Wed:03:00"
     rds_backup_window          = "03:00-06:00"
@@ -122,9 +116,6 @@ rds_databases = {
           },
         ]
       },
-      {
-        option_name = "JVM"
-      }
     ]
   },
   wck = {
@@ -135,7 +126,7 @@ rds_databases = {
     engine                     = "oracle-se2"
     major_engine_version       = "19"
     engine_version             = "19"
-    auto_minor_version_upgrade = true
+    auto_minor_version_upgrade = false
     license_model              = "license-included"
     rds_maintenance_window     = "Wed:00:00-Wed:03:00"
     rds_backup_window          = "03:00-06:00"
@@ -160,9 +151,6 @@ rds_databases = {
           },
         ]
       },
-      {
-        option_name = "JVM"
-      }
     ]
   },
   cics = {

--- a/groups/sessions/profiles/heritage-development-eu-west-2/vars
+++ b/groups/sessions/profiles/heritage-development-eu-west-2/vars
@@ -114,6 +114,31 @@ parameter_group_settings = [
     },
 ]
 
+option_group_settings = [
+  {
+    option_name = "JVM"
+  },
+  {
+    option_name = "SQLT"
+    version     = "2018-07-25.v1"
+    option_settings = [
+      {
+        name  = "LICENSE_PACK"
+        value = "N"
+      },
+    ]
+  },
+  {
+    option_name = "Timezone"
+    option_settings = [
+      {
+        name  = "TIME_ZONE"
+        value = "Europe/London"
+      },
+    ]
+  }
+]
+
 rds_schedule_enable = true
 rds_start_schedule = "cron(0 5 * * ? *)"
 rds_stop_schedule = "cron(0 21 * * ? *)"

--- a/groups/sessions/profiles/heritage-live-eu-west-2/vars
+++ b/groups/sessions/profiles/heritage-live-eu-west-2/vars
@@ -125,6 +125,31 @@ parameter_group_settings = [
     },
 ]
 
+option_group_settings = [
+  {
+    option_name = "JVM"
+  },
+  {
+    option_name = "SQLT"
+    version     = "2018-07-25.v1"
+    option_settings = [
+      {
+        name  = "LICENSE_PACK"
+        value = "N"
+      },
+    ]
+  },
+  {
+    option_name = "Timezone"
+    option_settings = [
+      {
+        name  = "TIME_ZONE"
+        value = "Europe/London"
+      },
+    ]
+  }
+]
+
 ## CloudWatch Alarms
 alarm_actions_enabled  = true
 alarm_topic_name       = "Email_Alerts"

--- a/groups/sessions/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/sessions/profiles/heritage-staging-eu-west-2/vars
@@ -22,7 +22,7 @@ rds_backup_window       = "03:00-06:00"
 major_engine_version       = "19"
 engine_version             = "19"
 license_model              = "license-included"
-auto_minor_version_upgrade = true
+auto_minor_version_upgrade = false
 
 rds_onpremise_access = [
   "10.65.2.0/24",
@@ -115,6 +115,28 @@ parameter_group_settings = [
       name  = "workarea_size_policy"
       value = "AUTO"
     },
+]
+
+option_group_settings = [
+  {
+    option_name = "SQLT"
+    version     = "2018-07-25.v1"
+    option_settings = [
+      {
+        name  = "LICENSE_PACK"
+        value = "N"
+      },
+    ]
+  },
+  {
+    option_name = "Timezone"
+    option_settings = [
+      {
+        name  = "TIME_ZONE"
+        value = "Europe/London"
+      },
+    ]
+  }
 ]
 
 rds_schedule_enable = true

--- a/groups/sessions/rds.tf
+++ b/groups/sessions/rds.tf
@@ -149,35 +149,13 @@ module "sessions_rds" {
 
   parameters = var.parameter_group_settings
 
-  options = [
+  options = concat([
     {
       option_name                    = "OEM"
       port                           = "5500"
       vpc_security_group_memberships = [module.rds_security_group.this_security_group_id]
-    },
-    {
-      option_name = "JVM"
-    },
-    {
-      option_name = "SQLT"
-      version     = "2018-07-25.v1"
-      option_settings = [
-        {
-          name  = "LICENSE_PACK"
-          value = "N"
-        },
-      ]
-    },
-    {
-      option_name = "Timezone"
-      option_settings = [
-        {
-          name  = "TIME_ZONE"
-          value = "Europe/London"
-        },
-      ]
     }
-  ]
+  ], var.option_group_settings)
 
   timeouts = {
     "create" : "80m",

--- a/groups/sessions/variables.tf
+++ b/groups/sessions/variables.tf
@@ -74,6 +74,11 @@ variable "parameter_group_settings" {
   description = "A list of parameters that will be set in the RDS instance parameter group"
 }
 
+variable "option_group_settings" {
+  type        = any
+  description = "A list of options that will be set in the RDS instance option group"
+}
+
 variable "rds_onpremise_access" {
   type        = list(string)
   description = "A list of CIDR ranges or IPs to allow access from"


### PR DESCRIPTION
Moved RDS options in to vars to allow for per-profile changes
Updated rds.tf to concatenate standard OEM option with profile options
Removed JVM option and disabeld minor version upgrades in Staging