### PR TITLE
Add RDS ingress rules for CHD Admin Site service

### DIFF
--- a/groups/heritage-shared-infrastructure/profiles/heritage-development-eu-west-2/vars
+++ b/groups/heritage-shared-infrastructure/profiles/heritage-development-eu-west-2/vars
@@ -480,7 +480,8 @@ rds_ingress_groups = {
     "sgr-ewf-bep-asg*",
     "ewf-frontend-tuxedo*",
     "sgr-chd-bep-asg*",
-    "sgr-chd-fe-asg*"
+    "sgr-chd-fe-asg*",
+    "sgr-admin-sites-asg*"
   ],
   cics = []
 }

--- a/groups/heritage-shared-infrastructure/profiles/heritage-live-eu-west-2/vars
+++ b/groups/heritage-shared-infrastructure/profiles/heritage-live-eu-west-2/vars
@@ -469,7 +469,8 @@ rds_ingress_groups = {
     "ewf-frontend-tuxedo*",
     "sgr-chd-bep-asg*",
     "sgr-chd-fe-asg*",
-    "sgr-chips-oltp-db*"
+    "sgr-chips-oltp-db*",
+    "sgr-admin-sites-asg*"
   ],
   cics = [
     "sgr-windows-workloads-bus-obj-1-server*"

--- a/groups/heritage-shared-infrastructure/profiles/heritage-staging-eu-west-2/vars
+++ b/groups/heritage-shared-infrastructure/profiles/heritage-staging-eu-west-2/vars
@@ -474,7 +474,8 @@ rds_ingress_groups = {
     "sgr-chd-bep-asg*",
     "sgr-chd-fe-asg*",
     "sgr-chips-oltp-db*",
-    "sgr-chips-rep-db*"
+    "sgr-chips-rep-db*",
+    "sgr-admin-sites-asg*"
   ],
   cics = []
 }


### PR DESCRIPTION
This update adds security group ingress rules allowing access to the `chddb` RDS instances from CHD Admin Site services via security groups with the `sgr-admin-sites-asg` name prefix.